### PR TITLE
helpdesk_mgmt: add assigned user domain

### DIFF
--- a/helpdesk_mgmt/i18n/es.po
+++ b/helpdesk_mgmt/i18n/es.po
@@ -463,7 +463,7 @@ msgstr "Fecha de asignación"
 #. module: helpdesk_mgmt
 #: model:ir.model.fields,field_description:helpdesk_mgmt.field_helpdesk_ticket__user_id
 msgid "Assigned user"
-msgstr "Usuario asignado"
+msgstr "Asignado a"
 
 #. module: helpdesk_mgmt
 #: model_terms:ir.ui.view,arch_db:helpdesk_mgmt.view_helpdesk_ticket_kanban
@@ -1500,4 +1500,3 @@ msgstr "Mensajes de la Web"
 #: model:ir.model.fields,help:helpdesk_mgmt.field_helpdesk_ticket_team__website_message_ids
 msgid "Website communication history"
 msgstr ""
-

--- a/helpdesk_mgmt/views/helpdesk_ticket_views.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_views.xml
@@ -118,8 +118,8 @@
                             <field name="user_ids" invisible="1" readonly="1" />
                             <field
                                 name="user_id"
-                                domain="[('share', '=', False)]"
-                                options='{"always_reload": True}'
+                                domain="[('share', '=', False), ('id', 'in', user_ids)]"
+                                options="{'always_reload': True, 'no_create ': True, 'no_create_edit' : True}"
                             />
                             <field
                                 name="company_id"


### PR DESCRIPTION
We added the domain for the assigned user to only display the members of the selected team.