### PR TITLE
helpdesk_mgmt: add user domain in Teams

### DIFF
--- a/helpdesk_mgmt/i18n/es.po
+++ b/helpdesk_mgmt/i18n/es.po
@@ -1331,12 +1331,12 @@ msgstr ""
 
 #. module: helpdesk_mgmt
 #: model:ir.model.fields,help:helpdesk_mgmt.field_helpdesk_ticket_team__alias_user_id
-msgid ""
+msgid "Assign to"
 "The owner of records created upon receiving emails on this alias. If this "
 "field is not set the system will attempt to find the right owner based on "
 "the sender (From) address, or will use the Administrator account if no "
 "system user is found for that address."
-msgstr ""
+msgstr "Asignar a"
 
 #. module: helpdesk_mgmt
 #: model:mail.template,subject:helpdesk_mgmt.closed_ticket_template

--- a/helpdesk_mgmt/views/helpdesk_ticket_team_views.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_team_views.xml
@@ -81,7 +81,7 @@
                             <field
                                 name="alias_user_id"
                                 string="Assign to"
-                                domain="['|', ('share', '=', False)]"
+                                domain="[('share', '=', False)]"
                             />
                             <field
                                 name="company_id"

--- a/helpdesk_mgmt/views/helpdesk_ticket_team_views.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_team_views.xml
@@ -105,6 +105,7 @@
                                         name="user_ids"
                                         widget="many2many_tags"
                                         class="mt16"
+                                        domain="[('share', '=', False)]"
                                     />
                                 </div>
                             </div>

--- a/helpdesk_mgmt/views/helpdesk_ticket_team_views.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_team_views.xml
@@ -78,7 +78,11 @@
                                 class="oe_inline"
                                 string="Accept Emails From"
                             />
-                            <field name="alias_user_id" string="Assign to" />
+                            <field
+                                name="alias_user_id"
+                                string="Assign to"
+                                domain="[('id', 'in', user_ids)]"
+                            />
                             <field
                                 name="company_id"
                                 options="{'no_create': True}"

--- a/helpdesk_mgmt/views/helpdesk_ticket_team_views.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_team_views.xml
@@ -81,7 +81,7 @@
                             <field
                                 name="alias_user_id"
                                 string="Assign to"
-                                domain="[('id', 'in', user_ids)]"
+                                domain="['|', ('share', '=', False)]"
                             />
                             <field
                                 name="company_id"

--- a/helpdesk_mgmt/views/helpdesk_ticket_views.xml
+++ b/helpdesk_mgmt/views/helpdesk_ticket_views.xml
@@ -115,7 +115,7 @@
                             <field name="user_ids" invisible="1" readonly="1" />
                             <field
                                 name="user_id"
-                                domain="[('share', '=', False), ('id', 'in', user_ids)]"
+                                domain="['|', ('id', 'in', user_ids), ('share', '=', False)]"
                                 options="{'always_reload': True, 'no_create ': True, 'no_create_edit' : True}"
                             />
                             <field


### PR DESCRIPTION
We changed the domain of users in Teams view to only select members that are part of the team.