### PR TITLE
[FIX] helpdesk_mgmt: automatic stage

### DIFF
--- a/helpdesk_mgmt/models/helpdesk_ticket.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket.py
@@ -153,7 +153,11 @@ class HelpdeskTicket(models.Model):
         string="Next stage date", compute="_compute_next_stage"
     )
 
-    @api.depends("stage_id")
+    @api.depends(
+        "stage_id.auto_next_number",
+        "stage_id.auto_next_type",
+        "stage_id.auto_next_stage_id",
+    )
     def _compute_next_stage(self):
         for record in self:
             if (

--- a/helpdesk_mgmt/models/helpdesk_ticket_stage.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket_stage.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime
 
 from odoo import api, fields, models
 

--- a/helpdesk_mgmt/models/helpdesk_ticket_stage.py
+++ b/helpdesk_mgmt/models/helpdesk_ticket_stage.py
@@ -51,18 +51,6 @@ class HelpdeskTicketStage(models.Model):
         comodel_name="helpdesk.ticket", inverse_name="stage_id", string="Tickets",
     )
 
-    @staticmethod
-    def compute_next_datetime(
-        date: datetime, increment: int, auto_type: str
-    ) -> datetime:
-        _date = timedelta(hours=increment) + date
-        if auto_type == "day":
-            _date = timedelta(days=increment) + date
-        elif auto_type == "week":
-            _date = timedelta(weeks=increment) + date
-
-        return _date
-
     # called by cron
     @api.model
     def change_stage(self):
@@ -73,12 +61,7 @@ class HelpdeskTicketStage(models.Model):
                 and stage_id.auto_next_stage_id
             ):
                 for ticket_id in stage_id.ticket_ids.filtered(
-                    lambda x: datetime.now()
-                    > self.compute_next_datetime(
-                        x.auto_last_update,
-                        self.auto_next_number,
-                        self.auto_next_stage_id.auto_next_type,
-                    )
+                    lambda x: datetime.now() > x.ticket_change
                 ):
                     ticket_id.stage_id = stage_id.auto_next_stage_id.id
                     ticket_id.auto_last_update = datetime.now()

--- a/helpdesk_mgmt/tests/test_helpdesk_ticket.py
+++ b/helpdesk_mgmt/tests/test_helpdesk_ticket.py
@@ -152,6 +152,7 @@ class TestHelpdeskTicket(common.SavepointCase):
         self.assertEqual(len(self.auto_assign_ticket_id.user_id), 0)
         self.ticket._onchange_domain_user_id()
         self.ticket._compute_domain_user_id()
+        self.ticket._compute_next_stage()
 
         # Fixed
         self.team_id.auto_assign_type = "fixed"


### PR DESCRIPTION
The date in which the ticket had to change its stage was been computed but, apparently,
not stored properly, so the ticket moved every time the cron was executed.
We fixed this by setting a computed field for the date the ticket had to change its stage.